### PR TITLE
Bug Repair: Cross-Server Deposit Not Working

### DIFF
--- a/lib/DestinationChannel.php
+++ b/lib/DestinationChannel.php
@@ -41,14 +41,17 @@ class DestinationChannel extends ChannelConnection
                 $content = $message->author->username . ": ". $message->content;
 
                 #if channel is found, send the message to the channel for this deposit connection.
-                $channel->sendMessage($content);
-                return 1;
+                $channel->sendMessage($content)->then(function ($message) {
+                    return 1;
+                })->otherwise(function ($e) {
+                    return 0;
+                });
+                return 0;
 
             }
             return 0;
 
-        }
-        
+        }      
         return 0;
     }
 

--- a/lib/config_manager.php
+++ b/lib/config_manager.php
@@ -62,7 +62,7 @@ class config_manager
                     if(!$this->SourceMonitors[$monitorNick]) throw new Exception("Invalid configuration; The monitor '$monitorNick' specified in destination '$destNickname' does not exist.");
 
                     #create a monitor record, and add it to source monitors collection
-                    $destination = new DestinationChannel($source['guildID'], $destChanId, $monitorNick, ($useAltNick ? $altNick : $destNickname));
+                    $destination = new DestinationChannel($dest['guildID'], $destChanId, $monitorNick, ($useAltNick ? $altNick : $destNickname));
                     $this->DestinationConnections[($useAltNick ? $altNick : $destNickname)] = $destination;
                 }
 

--- a/wumpus-copy.php
+++ b/wumpus-copy.php
@@ -65,7 +65,7 @@ $depositReadyHandler = function(Discord $discord) use($config) {
 };
 
 #add the queue processing periodic loop to the main loop.
-$mainLoop->addPeriodicTimer($config->get_queue_interval(), function() use ($config, $depositDiscord) {
+$queueProcessLoop = function() use ($config, $depositDiscord) {
     #copy current instance of queue as to not disturb adding new messages during queue processing.
     $queue = $config->get_deposit_queue();
 
@@ -100,7 +100,8 @@ $mainLoop->addPeriodicTimer($config->get_queue_interval(), function() use ($conf
 
     #clear deposit queue of messages that were processed this cycle.
     $config->clear_deposit_queue($queue);
-});
+};
+$mainLoop->addPeriodicTimer($config->get_queue_interval(), $queueProcessLoop);
 
 
 #add handlers


### PR DESCRIPTION
A typo in the configuration manager class had caused created deposit connections to always load the last 'guildID' value from the last monitor defined instead of from the deposit configuration node; resulting in the wrong lookup of the GuildID at queue process time.