### PR TITLE
Improve Message Delivery Error Handling

### DIFF
--- a/wumpus-copy.php
+++ b/wumpus-copy.php
@@ -118,7 +118,7 @@ $queueProcessLoop = function() use ($config, $depositDiscord) {
 
         } elseif($errors > 0 && $sent > 0) {
             #if errors and successes occurred
-            say("[Deposit]: All queue items processed successfully; sent '" . $sent . "' message(s).");
+            say("[Deposit]: WARNING! '" . $sent . "' message(s) sent successfully, but '" . $errors . "' errors occured!");
 
         } elseif($errors > 0 && $sent == 0) {
             #if no successes occurred

--- a/wumpus-copy.php
+++ b/wumpus-copy.php
@@ -96,36 +96,29 @@ $queueProcessLoop = function() use ($config, $depositDiscord) {
 
             #find all applicable destinations for each message in queue.
             $destinations = $config->get_deposits_for_source_channel($message->channel_id);
-            $errorMessages = array();
 
             #loop through them.
             foreach($destinations as $destination) {
 
-                #process message with destination
-                $result = $destination->send_message($config, $depositDiscord, $message);
-                if($result != 1) {
-                    $errors += 1;
-                    $errorMessages["error$errors"] = var_export($message, true);
-                    
-                } else {
+                try {
+
+                    #process message with destination
+                    $result = $destination->send_message($config, $depositDiscord, $message);
                     $sent += 1;
+                    
+                } catch(Throwable $ex) {
+
                 }
+
             }
 
         }
 
         #report how many queued items were processed, and report errors if any
-        if($errors == 0 && $sent > 0) {
+        if($sent > 0) {
+            
             #if no errors occurred
-            say("[Deposit]: All queue items processed successfully; sent '" . $sent . "' message(s).");
-
-        } elseif($errors > 0 && $sent > 0) {
-            #if errors and successes occurred
-            say("[Deposit]: WARNING! '" . $sent . "' message(s) sent successfully, but '" . $errors . "' errors occured!");
-
-        } elseif($errors > 0 && $sent == 0) {
-            #if no successes occurred
-            say("[Deposit]: ERROR! All {$errors} queue items failed to process.");
+            say("[Deposit]: Queue items processed successfully; sent '" . $sent . "' message(s).");
 
         }
     }

--- a/wumpus-copy.php
+++ b/wumpus-copy.php
@@ -96,6 +96,7 @@ $queueProcessLoop = function() use ($config, $depositDiscord) {
 
             #find all applicable destinations for each message in queue.
             $destinations = $config->get_deposits_for_source_channel($message->channel_id);
+            $errorMessages = array();
 
             #loop through them.
             foreach($destinations as $destination) {
@@ -104,6 +105,8 @@ $queueProcessLoop = function() use ($config, $depositDiscord) {
                 $result = $destination->send_message($config, $depositDiscord, $message);
                 if($result != 1) {
                     $errors += 1;
+                    $errorMessages["error$errors"] = var_export($message, true);
+                    
                 } else {
                     $sent += 1;
                 }


### PR DESCRIPTION
Messages would say they would fail to process in the deposit queue, when in fact their copies were already delivered.

this was fixed by changing the way the deposit queue determines delivery failure.