### PR TITLE
Support Unstable Builds with Jenkins

### DIFF
--- a/compile/linux/Jenkinsfile
+++ b/compile/linux/Jenkinsfile
@@ -52,7 +52,15 @@ pipeline {
         }
         stage('Execute Tests') {
             steps {
-                sh './vendor/phpunit/phpunit/phpunit --configuration ./test/phpunit.xml'
+                script {
+                    try {
+                        sh './vendor/phpunit/phpunit/phpunit --configuration ./test/phpunit.xml'
+                    }
+                    catch (exc) {
+                        echo 'WARNING: Tests Failed! Attempting to continue with package build'
+                        currentBuild.result = 'UNSTABLE'
+                    }
+                }
             }
         }
         stage('Remove Composer Packages') {
@@ -73,6 +81,9 @@ pipeline {
         }
         failure {
             setBuildStatus('Failure', 'FAILURE')
+        }
+        unstable {
+            setBuildStatus('Unstable', 'UNSTABLE')
         }
         always {
             archiveArtifacts artifacts: 'build/*.deb', fingerprint: true

--- a/compile/linux/Jenkinsfile
+++ b/compile/linux/Jenkinsfile
@@ -57,9 +57,8 @@ pipeline {
                         sh './vendor/phpunit/phpunit/phpunit --configuration ./test/phpunit.xml'
                     }
                     catch (exc) {
-                        echo 'WARNING: Tests Failed! Attempting to continue with package build'
+                        echo 'WARNING: Tests Failed! Attempting to continue with package build...'
                         currentBuild.result = 'UNSTABLE'
-                        setBuildStatus('Unstable', 'UNSTABLE')
                     }
                 }
             }

--- a/compile/linux/Jenkinsfile
+++ b/compile/linux/Jenkinsfile
@@ -57,7 +57,6 @@ pipeline {
                         sh './vendor/phpunit/phpunit/phpunit --configuration ./test/phpunit.xml'
                     }
                     catch (exc) {
-                        echo 'WARNING: Tests Failed! Attempting to continue with package build'
                         currentBuild.result = 'UNSTABLE'
                     }
                 }

--- a/compile/linux/Jenkinsfile
+++ b/compile/linux/Jenkinsfile
@@ -57,7 +57,9 @@ pipeline {
                         sh './vendor/phpunit/phpunit/phpunit --configuration ./test/phpunit.xml'
                     }
                     catch (exc) {
+                        echo 'WARNING: Tests Failed! Attempting to continue with package build'
                         currentBuild.result = 'UNSTABLE'
+                        setBuildStatus('Unstable', 'UNSTABLE')
                     }
                 }
             }

--- a/test/configuration_manager/config_manager_tests.php
+++ b/test/configuration_manager/config_manager_tests.php
@@ -6,7 +6,6 @@ require __DIR__ . '/../../lib/requires.php';
 class ConfigurationManagerTests extends TestCase
 {
     public function testInvalid_Parsing_1() {
-        $this->assertFalse(true);
         $this->expectException(Exception::class);
         $testConfig = new config_manager(__DIR__ . "/json/testConfig_invalid_badjson1.json");
     }

--- a/test/configuration_manager/config_manager_tests.php
+++ b/test/configuration_manager/config_manager_tests.php
@@ -6,9 +6,9 @@ require __DIR__ . '/../../lib/requires.php';
 class ConfigurationManagerTests extends TestCase
 {
     public function testInvalid_Parsing_1() {
+        $this->assertFalse(true);
         $this->expectException(Exception::class);
         $testConfig = new config_manager(__DIR__ . "/json/testConfig_invalid_badjson1.json");
-
     }
     public function testInvalid_Parsing_2() {
         $this->expectException(Exception::class);


### PR DESCRIPTION
Allow builds to continue if tests fail, but mark the package's build in Jenkins as unstable.